### PR TITLE
add opencontainer labels and annotations to docker builds

### DIFF
--- a/.github/workflows/dockerimage-main.yml
+++ b/.github/workflows/dockerimage-main.yml
@@ -36,6 +36,12 @@ jobs:
           username: ${{ secrets.DOCKER_NAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: dungfu/twitch-drops-miner
+
       - name: Build and push tinkter temp tags
         uses: docker/build-push-action@v7
         with:
@@ -45,6 +51,7 @@ jobs:
           push: ${{ github.event_name == 'release' }}
           tags: |
             dungfu/twitch-drops-miner:temp-tkinter-${{ matrix.arch }}-${{ github.run_id }}
+          labels: ${{ steps.meta.outputs.labels }}
           pull: true
           no-cache: true
 
@@ -78,6 +85,12 @@ jobs:
           username: ${{ secrets.DOCKER_NAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: dungfu/twitch-drops-miner
+
       - name: Build and push nicegui temp tags
         uses: docker/build-push-action@v7
         with:
@@ -87,6 +100,7 @@ jobs:
           push: ${{ github.event_name == 'release' }}
           tags: |
             dungfu/twitch-drops-miner:temp-nicegui-${{ matrix.arch }}-${{ github.run_id }}
+          labels: ${{ steps.meta.outputs.labels }}
           pull: true
           no-cache: true
 
@@ -113,6 +127,12 @@ jobs:
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Extract Docker metadata for Manifest Index
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: dungfu/twitch-drops-miner
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -133,48 +153,29 @@ jobs:
             NICEGUI_TEMP_TAGS+=("dungfu/twitch-drops-miner:temp-nicegui-${arch}-${{ github.run_id }}")
           done
 
+          ANNOTATION_ARGS=()
+          while IFS= read -r line; do
+            if [ -n "$line" ]; then
+              ANNOTATION_ARGS+=("--annotation" "$line")
+            fi
+          done <<< "${{ steps.meta.outputs.annotations }}"
+
           # Create tkinter version tag
           docker buildx imagetools create \
+            "${ANNOTATION_ARGS[@]}" \
             -t dungfu/twitch-drops-miner:tkinter-${{ steps.version.outputs.version }} \
-            "${TKINTER_TEMP_TAGS[@]}"
-
-          # Create tkinter dev tag
-          docker buildx imagetools create \
             -t dungfu/twitch-drops-miner:tkinter-16.dev \
-            "${TKINTER_TEMP_TAGS[@]}"
-
-          # Create tkinter tag
-          docker buildx imagetools create \
             -t dungfu/twitch-drops-miner:tkinter \
             "${TKINTER_TEMP_TAGS[@]}"
 
           # Create webui version tag
           docker buildx imagetools create \
+            "${ANNOTATION_ARGS[@]}" \
             -t dungfu/twitch-drops-miner:webui-${{ steps.version.outputs.version }} \
-            "${NICEGUI_TEMP_TAGS[@]}"
-
-          # Create webui dev tag
-          docker buildx imagetools create \
             -t dungfu/twitch-drops-miner:webui-16.dev \
-            "${NICEGUI_TEMP_TAGS[@]}"
-
-          # Create webui tag
-          docker buildx imagetools create \
             -t dungfu/twitch-drops-miner:webui \
-            "${NICEGUI_TEMP_TAGS[@]}"
-
-          # Create version tag
-          docker buildx imagetools create \
             -t dungfu/twitch-drops-miner:${{ steps.version.outputs.version }} \
-            "${NICEGUI_TEMP_TAGS[@]}"
-
-          # Create dev tag
-          docker buildx imagetools create \
             -t dungfu/twitch-drops-miner:16.dev \
-            "${NICEGUI_TEMP_TAGS[@]}"
-
-          # Create latest tag
-          docker buildx imagetools create \
             -t dungfu/twitch-drops-miner:latest \
             "${NICEGUI_TEMP_TAGS[@]}"
 

--- a/Dockerfile.tkinter
+++ b/Dockerfile.tkinter
@@ -15,7 +15,10 @@ RUN apk add --no-cache ca-certificates wget unzip && \
 # Final image
 FROM jlesage/baseimage-gui:alpine-3.23-v4
 
-LABEL maintainer="fireph"
+LABEL org.opencontainers.image.authors="fireph" \
+      org.opencontainers.image.title="Twitch Drops Miner (Tkinter)" \
+      org.opencontainers.image.description="A Dockerized miner for Twitch Drops featuring the Tkinter desktop UI" \
+      org.opencontainers.image.source="https://github.com/fireph/docker-twitch-drops-miner"
 
 # Environment
 ENV ENABLE_CJK_FONT=1

--- a/Dockerfile.webui
+++ b/Dockerfile.webui
@@ -15,7 +15,10 @@ RUN apk add --no-cache ca-certificates wget unzip && \
 # Final image
 FROM alpine:latest
 
-LABEL maintainer="fireph"
+LABEL org.opencontainers.image.authors="fireph" \
+      org.opencontainers.image.title="Twitch Drops Miner (WebUI)" \
+      org.opencontainers.image.description="A Dockerized miner for Twitch Drops featuring the NiceGUI web interface" \
+      org.opencontainers.image.source="https://github.com/fireph/docker-twitch-drops-miner"
 
 # Environment
 ENV TDM_VERSION_TAG=16.dev.42a490f


### PR DESCRIPTION
This adds opencontainer labels and annotations to the built docker containers, this enables tools like renovate to pull in changelogs for the images on update. I also believe that instead of having separate imagetools create calls you can pass multiple tags.

Because I don't have push rights to the target Docker registry, I wasn't able to do a full end-to-end test of the workflow to verify the push steps. The logic is solid, but it may require minor tweaking once it runs against the live repository. Feel free to make any changes or suggestions!

Also, would you be open to another PR that simultaneously pushes builds to GHCR?
https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry